### PR TITLE
Upgrade from Fedora 24=>25, remove CentOS5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ services:
 script:
 - >
   wget -O- bit.ly/ansibletest | env
-  DOCKER_IMAGES="centos:5 centos:6 ubuntu:14.04
-  fedora:21 fedora:22 fedora:23 debian:7 debian:stretch"
+  DOCKER_IMAGES="centos:6 ubuntu:14.04
+  fedora:21 fedora:22 fedora:23 fedora:25 debian:7 debian:stretch"
   ANSIBLE_VERSIONS="1.4.4 1.6.1 1.9.2 2.0.0.2 2.1.0.0"
   sh
 after_failure:

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
       - >
         wget -qO- bit.ly/ansibletest | env
         DOCKER_IMAGES="centos:7 ubuntu:12.04 ubuntu:16.04 fedora:20
-        fedora:24 debian:8"
+        fedora:25 debian:8"
         ANSIBLE_VERSIONS="system 1.4 1.5.4 1.6.1 1.7.2 1.8.4 1.9.2 2.0.0.2
         2.1.0.0 2.2.1.0"
         sh

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -62,6 +62,8 @@ galaxy_info:
     - 21
     - 22
     - 23
+    - 24
+    - 25
   #- name: opensuse
   #  versions:
   #  - all


### PR DESCRIPTION
CentOS5 is end-of-lifed
https://bugzilla.redhat.com/show_bug.cgi?id=1440366